### PR TITLE
Remove unnecessary chimeric alignment filtering

### DIFF
--- a/coral/breakpoint/breakpoint_utilities.py
+++ b/coral/breakpoint/breakpoint_utilities.py
@@ -783,8 +783,6 @@ def fetch_breakpoint_reads(
         chimeric_alignments[r] = cigar_parsing.alignment_from_satags(
             chimeric_strings[r], r
         )
-    for r in reads_wo_primary_alignment:
-        del chimeric_alignments[r]
     logger.info(
         f"Computed alignment intervals on all {len(chimeric_strings)} chimeric reads.",
     )


### PR DESCRIPTION
Fix issues related to breakpoint graph modularization updates. Previously `chimeric_alignments` was used to store chimeric Cigar Strings, then updated in-place to represent Chimeric Alignments with a list data structure storing the reference genomic coordinates. Now that we use separate variables (`chimeric_strings` + `chimeric_alignments`) to store the cigar strings + reference coordinates, we don't need to apply this filter.