### PR TITLE
Disable verbose SCIP output to avoid creating gigabytes of logs

### DIFF
--- a/coral/models/cycle_utils.py
+++ b/coral/models/cycle_utils.py
@@ -326,8 +326,6 @@ def get_solver(
         raw_solver.options["timelimit"] = solver_time_limit
     elif solver_type == datatypes.Solver.SCIP:
         raw_solver.options["limits/time"] = solver_time_limit
-        raw_solver.options["display/freq"] = 1
-        raw_solver.options["display/lpinfo"] = True
 
         # Threads are only respected when using "Fiber-SCIP" executable
         # raw_solver.options["lp/threads"] = solver_options.num_threads


### PR DESCRIPTION
On very large datasets, we have seen that CoRAL can output extremely large (e.g., 13GB) log files when using SCIP. This is because it enables verbose logging in the list of options passed to SCIP. Resolve this issue by removing these options.