### PR TITLE
Fix/discordant edge directionality

### DIFF
--- a/coral/breakpoint/breakpoint_utilities.py
+++ b/coral/breakpoint/breakpoint_utilities.py
@@ -705,10 +705,17 @@ def output_breakpoint_graph_lr(g: BreakpointGraph, ogfile: str, pc_option: Outpu
                 f"{ce.node2.chr}:{ce.node2.pos}{ce.node2.strand}\t"
                 f"{ce.cn}\t{ce.lr_count}\n"
             )
-        for de in sorted(g.discordant_edges):
+        # Write each SV with the lower-coordinate end first (earlier chromosome
+        # first if inter-chromosomal) so the directionality matches the AA
+        # convention; internally node1/node2 are ordered by detection, not
+        # coordinate. Sort the lines by that same canonical first endpoint.
+        for de in sorted(
+            g.discordant_edges, key=lambda e: e.ordered_nodes[0].sort_key
+        ):
+            first, second = de.ordered_nodes
             fp.write(
-                f"discordant\t{de.node1.chr}:{de.node1.pos}{de.node1.strand}->"
-                f"{de.node2.chr}:{de.node2.pos}{de.node2.strand}\t"
+                f"discordant\t{first.chr}:{first.pos}{first.strand}->"
+                f"{second.chr}:{second.pos}{second.strand}\t"
                 f"{de.cn}\t{de.lr_count}\n"
             )
         # Only output the longest path constraints (post subpath filtering)

--- a/coral/core_types.py
+++ b/coral/core_types.py
@@ -29,6 +29,18 @@ def chr_sort_key(name: str) -> tuple[int, int, str]:
     except ValueError:
         return (1, 2, stem)
 
+
+def is_canonical_chr(name: str) -> bool:
+    """Whether `name` is a primary chromosome (autosome, X, Y, or MT).
+
+    Genome-agnostic replacement for the former hardcoded hg38 ``CHR_TAG_TO_IDX``
+    membership test: returns True for chr1..chrN, chrX, chrY, chrM/chrMT (with
+    or without the ``chr`` prefix), and False for decoy/alt/unplaced contigs
+    (e.g. ``chrUn_*``, ``*_random``, ``*_alt``, ``HLA-*``, ``chrEBV``).
+    """
+    stem = name.removeprefix("chr")
+    return stem.isdigit() or stem in ("X", "Y", "M", "MT")
+
 ChrTag = str  # Chromosome identifier, in the form `chr<name>`
 CNSIdx = int
 ReadName = str

--- a/coral/datatypes.py
+++ b/coral/datatypes.py
@@ -135,6 +135,17 @@ class Node(NamedTuple):
     def __repr__(self) -> str:
         return self.__str__()
 
+    @property
+    def sort_key(self) -> tuple[tuple[int, int, str], int, int]:
+        """Genomic ordering key: earlier chromosome, then lower position, then
+        reverse strand before forward (matching AmpliconArchitect's
+        ``absPos + 0.4 * strand`` vertex ordering)."""
+        return (
+            core_types.chr_sort_key(self.chr),
+            self.pos,
+            0 if self.strand == Strand.REVERSE else 1,
+        )
+
 
 @dataclass
 class SplitInterval:
@@ -709,6 +720,16 @@ class BreakpointEdge:
 
     lr_count: int  # Long read count
     cn: float = 0.0  # Edge Copy Number
+
+    @property
+    def ordered_nodes(self) -> tuple[Node, Node]:
+        """The two endpoints ordered so the lower genomic coordinate (or earlier
+        chromosome, if inter-chromosomal) comes first. Used when writing the SV
+        to the graph file so its directionality matches the AmpliconArchitect
+        convention regardless of the order the breakpoint ends were detected."""
+        if self.node1.sort_key <= self.node2.sort_key:
+            return self.node1, self.node2
+        return self.node2, self.node1
 
     def __lt__(self, other: BreakpointEdge) -> bool:
         return (

--- a/coral/hsr.py
+++ b/coral/hsr.py
@@ -15,7 +15,7 @@ from coral.breakpoint.breakpoint_utilities import (
     interval2bp,
     interval_overlap_l,
 )
-from coral.constants import CHR_TAG_TO_IDX
+from coral.core_types import is_canonical_chr
 from coral.datatypes import BPAlignments, Interval
 from coral.global_state import STATE_PROVIDER
 
@@ -139,7 +139,12 @@ def locate_hsrs(
     for r in chimeric_alignments:
         cycle_flag = False
         cas = chimeric_alignments[r]
-        cas = [ca for ca in cas if ca.ref_interval.chr in CHR_TAG_TO_IDX]
+        # Keep only alignments on primary chromosomes, dropping decoy/alt/
+        # unplaced contigs. Genome-agnostic replacement for the former hardcoded
+        # hg38 CHR_TAG_TO_IDX membership test. Deliberately independent of the
+        # CN-seg file so HSR integration sites on otherwise-normal chromosomes
+        # are retained even when the CN input is sparse (e.g. a .bed of calls).
+        cas = [ca for ca in cas if is_canonical_chr(ca.ref_interval.chr)]
         ref_intvs = [ca.ref_interval for ca in cas]
         for interval in ecdna_intervals:
             i = interval_overlap_l(interval, ref_intvs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = "MIT"
 name = "CoRAL"
 readme = 'README.md'
 repository = "https://github.com/AmpliconSuite/CoRAL"
-version = "3.0.0"
+version = "3.0.1"
 
 packages = [{ include = "coral" }]
 

--- a/tests/test_discordant_edge_output_order.py
+++ b/tests/test_discordant_edge_output_order.py
@@ -1,0 +1,83 @@
+"""Tests for discordant-edge directionality in the graph output.
+
+A discordant edge (SV) must be written with its lower-coordinate end first
+(earlier chromosome first when inter-chromosomal), matching the
+AmpliconArchitect ``_graph.txt`` convention. Internally CoRAL stores
+``node1`` as the higher-coordinate end (see ``interval2bp`` / the ``bp_match``
+invariant), so the writer relies on ``DiscordantEdge.ordered_nodes`` to flip the
+endpoints when needed.
+
+The cases below mirror the three discordant edges from sample GBM39, whose
+directionality was being emitted reversed relative to AA before the fix.
+"""
+
+from coral.datatypes import DiscordantEdge, Node, Strand
+
+
+def fmt(node: Node) -> str:
+    return f"{node.chr}:{node.pos}{node.strand}"
+
+
+def edge_str(de: DiscordantEdge) -> str:
+    first, second = de.ordered_nodes
+    return f"{fmt(first)}->{fmt(second)}"
+
+
+# ---------------------------------------------------------------------------
+# GBM39 regression: stored node1 is the higher coordinate; output must lead
+# with the lower coordinate and keep each strand attached to its position.
+# ---------------------------------------------------------------------------
+
+def test_intrachromosomal_edges_written_lower_first() -> None:
+    cases = [
+        # (stored node1 [higher], stored node2 [lower], expected output)
+        (
+            Node("chr7", 55155021, Strand.REVERSE),
+            Node("chr7", 55127266, Strand.FORWARD),
+            "chr7:55127266+->chr7:55155021-",
+        ),
+        (
+            Node("chr7", 55610095, Strand.REVERSE),
+            Node("chr7", 55609190, Strand.FORWARD),
+            "chr7:55609190+->chr7:55610095-",
+        ),
+        (
+            Node("chr7", 56049369, Strand.FORWARD),
+            Node("chr7", 54763282, Strand.REVERSE),
+            "chr7:54763282-->chr7:56049369+",
+        ),
+    ]
+    for node1, node2, expected in cases:
+        de = DiscordantEdge(node1, node2, lr_count=1)
+        assert edge_str(de) == expected
+
+
+def test_already_lower_first_is_unchanged() -> None:
+    """An edge already stored lower-first must be emitted verbatim."""
+    de = DiscordantEdge(
+        Node("chr7", 54763282, Strand.REVERSE),
+        Node("chr7", 56049369, Strand.FORWARD),
+        lr_count=1,
+    )
+    assert edge_str(de) == "chr7:54763282-->chr7:56049369+"
+
+
+def test_interchromosomal_orders_by_chromosome() -> None:
+    """Earlier chromosome leads, regardless of position within each chrom."""
+    de = DiscordantEdge(
+        Node("chr5", 100, Strand.FORWARD),
+        Node("chr2", 900, Strand.REVERSE),
+        lr_count=1,
+    )
+    assert edge_str(de) == "chr2:900-->chr5:100+"
+
+
+def test_foldback_same_position_reverse_first() -> None:
+    """At an equal position the reverse-strand end is written first, matching
+    AA's ``absPos + 0.4 * strand`` vertex ordering."""
+    de = DiscordantEdge(
+        Node("chr7", 500, Strand.FORWARD),
+        Node("chr7", 500, Strand.REVERSE),
+        lr_count=1,
+    )
+    assert edge_str(de) == "chr7:500-->chr7:500+"

--- a/tests/test_merge_connected_amplicons.py
+++ b/tests/test_merge_connected_amplicons.py
@@ -1,0 +1,139 @@
+"""Tests for LongReadBamToBreakpointMetadata.merge_connected_amplicons.
+
+All tests operate purely on in-memory data structures; no BAM file is needed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from coral.breakpoint.infer_breakpoint_graph import LongReadBamToBreakpointMetadata
+from coral.core_types import Strand
+from coral.datatypes import AmpliconInterval, BPAlignments, Breakpoint, Node
+
+
+def make_metadata(
+    amplicon_intervals: list[AmpliconInterval],
+    new_bp_list: list[Breakpoint],
+) -> LongReadBamToBreakpointMetadata:
+    """Construct a minimal metadata object with the given intervals and BPs."""
+    obj = LongReadBamToBreakpointMetadata(
+        lr_bamfh=MagicMock(),
+        bam=MagicMock(),
+    )
+    obj.amplicon_intervals = amplicon_intervals
+    obj.new_bp_list = new_bp_list
+    return obj
+
+
+def make_bp(chr1: str, pos1: int, chr2: str, pos2: int) -> Breakpoint:
+    dummy_aln = BPAlignments(name="read1", alignment1=0, alignment2=1)
+    return Breakpoint(
+        node1=Node(chr=chr1, pos=pos1, strand=Strand.FORWARD),
+        node2=Node(chr=chr2, pos=pos2, strand=Strand.REVERSE),
+        alignment_info=dummy_aln,
+        gap=0,
+        was_reversed=False,
+        mapq1=60,
+        mapq2=60,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic merge: reproduces the crash case from SOG134_Pre_TM
+# ---------------------------------------------------------------------------
+
+def test_cross_amplicon_bp_merges_amplicons() -> None:
+    """Two intervals on chr2 with different amplicon_ids, connected by a BP,
+    should be unified into a single amplicon."""
+    intervals = [
+        AmpliconInterval(chr="chr2", start=185_370_001, end=186_410_682, amplicon_id=0),
+        AmpliconInterval(chr="chr2", start=188_815_619, end=191_281_309, amplicon_id=1),
+    ]
+    # BP mirrors the actual crash: chr2:188.9M → chr2:186.3M
+    bp = make_bp("chr2", 188_915_618, "chr2", 186_316_524)
+    meta = make_metadata(intervals, [bp])
+
+    meta.merge_connected_amplicons()
+
+    ids = {intv.amplicon_id for intv in meta.amplicon_intervals}
+    assert len(ids) == 1, "Both intervals should share one amplicon_id after merge"
+
+
+# ---------------------------------------------------------------------------
+# No merge when no connecting BP exists
+# ---------------------------------------------------------------------------
+
+def test_no_bp_keeps_amplicons_separate() -> None:
+    """Intervals with no connecting BP should retain distinct amplicon_ids."""
+    intervals = [
+        AmpliconInterval(chr="chr2", start=100_000, end=200_000, amplicon_id=0),
+        AmpliconInterval(chr="chr5", start=300_000, end=400_000, amplicon_id=1),
+    ]
+    meta = make_metadata(intervals, [])
+
+    meta.merge_connected_amplicons()
+
+    assert meta.amplicon_intervals[0].amplicon_id == 0
+    assert meta.amplicon_intervals[1].amplicon_id == 1
+
+
+# ---------------------------------------------------------------------------
+# BP within the same amplicon — no change
+# ---------------------------------------------------------------------------
+
+def test_intra_amplicon_bp_unchanged() -> None:
+    """A BP whose both endpoints fall in the same amplicon should not
+    change any amplicon_id."""
+    intervals = [
+        AmpliconInterval(chr="chr19", start=29_600_001, end=29_908_701, amplicon_id=2),
+        AmpliconInterval(chr="chr5",  start=500_000,    end=600_000,    amplicon_id=3),
+    ]
+    # Both ends of the BP land in the chr19 interval (amplicon_id=2)
+    bp = make_bp("chr19", 29_724_664, "chr19", 29_704_462)
+    meta = make_metadata(intervals, [bp])
+
+    meta.merge_connected_amplicons()
+
+    assert meta.amplicon_intervals[0].amplicon_id == 2
+    assert meta.amplicon_intervals[1].amplicon_id == 3
+
+
+# ---------------------------------------------------------------------------
+# Chain merge: A→B and B→C should all collapse into one amplicon
+# ---------------------------------------------------------------------------
+
+def test_chain_merge() -> None:
+    """Three amplicons connected A→B and B→C should all be merged."""
+    intervals = [
+        AmpliconInterval(chr="chr1", start=100_000, end=200_000, amplicon_id=0),
+        AmpliconInterval(chr="chr1", start=300_000, end=400_000, amplicon_id=1),
+        AmpliconInterval(chr="chr1", start=500_000, end=600_000, amplicon_id=2),
+    ]
+    bp_ab = make_bp("chr1", 150_000, "chr1", 350_000)
+    bp_bc = make_bp("chr1", 350_001, "chr1", 550_000)
+    meta = make_metadata(intervals, [bp_ab, bp_bc])
+
+    meta.merge_connected_amplicons()
+
+    ids = {intv.amplicon_id for intv in meta.amplicon_intervals}
+    assert len(ids) == 1, "All three intervals should collapse to one amplicon_id"
+
+
+# ---------------------------------------------------------------------------
+# BP endpoint outside all intervals — should skip gracefully, no crash
+# ---------------------------------------------------------------------------
+
+def test_bp_outside_intervals_is_skipped() -> None:
+    """A BP with one endpoint outside all known intervals should be skipped
+    without raising an exception."""
+    intervals = [
+        AmpliconInterval(chr="chr3", start=100_000, end=200_000, amplicon_id=0),
+    ]
+    # pos2 is far outside any interval
+    bp = make_bp("chr3", 150_000, "chr3", 999_999_999)
+    meta = make_metadata(intervals, [bp])
+
+    meta.merge_connected_amplicons()  # must not raise
+
+    assert meta.amplicon_intervals[0].amplicon_id == 0


### PR DESCRIPTION
This fixes an error in the ordering of the breakpoints written by CoRAL which affects visualizations and downstream interpretation of the graph file - for instance:

```
GBM39
    before:  chr7:56049369+ -> chr7:54763282-      after:  chr7:54763282- -> chr7:56049369+      (AA: chr7:54763279- ->
  chr7:56049369+)
    before:  chr7:55155021- -> chr7:55127266+      after:  chr7:55127266+ -> chr7:55155021-      (AA: chr7:55127266+ ->
  chr7:55155020-)

  HCC827
    before:  chr7:54403091+ -> chr7:54402258+      after:  chr7:54402258+ -> chr7:54403091+      (AA: chr7:54402258+ ->
  chr7:54403091+, exact)
    before:  chr7:54529740- -> chr7:54528793+      after:  chr7:54528793+ -> chr7:54529740-      (AA: chr7:54528799+ ->
  chr7:54529742-)
```

  Discordant edges were written leading with the higher-coordinate end, flipping SV orientation relative to the
  AmpliconArchitect convention; they now lead with the lower-coordinate end (earlier chromosome if inter-chromosomal),
  matching AA.
