### PR TITLE
Always write summary file when reconstruct runs

### DIFF
--- a/coral/cli.py
+++ b/coral/cli.py
@@ -251,6 +251,14 @@ def reconstruct(
         output_path_constraints,
         min_bp_support,
     )
+    # Write the summary immediately after graph reconstruction, so that it
+    # always exists downstream (AmpliconClassifier uses it as a marker that
+    # reconstruction ran), including when no amplicons were found, when cycle
+    # decomposition is skipped, or if decomposition is later interrupted.
+    summary.output.output_summary_amplicon_stats(
+        {bp_graph.amplicon_idx: False for bp_graph in b2bn.lr_graph},
+        b2bn.lr_graph,
+    )
     solver_options = datatypes.SolverOptions(
         num_threads=solver_threads,
         time_limit_s=solver_time_limit,

--- a/coral/cycle_decomposition.py
+++ b/coral/cycle_decomposition.py
@@ -691,7 +691,16 @@ def cycle_decomposition_all_graphs(
     ignore_path_constraints: bool = False,
 ) -> None:
     """Caller for cycle decomposition functions"""
-    was_amplicon_solved: Dict[int, bool] = defaultdict(bool)  # default false
+    # Default all amplicons to unsolved, so that the summary file exists (and
+    # reports the correct amplicon count) from the outset, even if no amplicons
+    # were found or decomposition is interrupted partway through.
+    was_amplicon_solved: Dict[int, bool] = defaultdict(
+        bool, {bp_graph.amplicon_idx: False for bp_graph in bp_graphs}
+    )
+    coral.summary.output.output_summary_amplicon_stats(
+        was_amplicon_solved, bp_graphs
+    )
+
     for bp_graph in bp_graphs:
         amplicon_idx = bp_graph.amplicon_idx
         cycle_decomposition_single_graph(

--- a/coral/summary/output.py
+++ b/coral/summary/output.py
@@ -85,7 +85,7 @@ def output_amplicon_info(
 def add_resource_usage_summary(solver_options: datatypes.SolverOptions) -> None:
     with global_state.STATE_PROVIDER.summary_filepath.open("a") as fp:
         fp.write(text_utils.AMPLICON_SEPARATOR + "\n")
-        fp.write("Solver Settings: \n")
+        fp.write(f"{text_utils.SOLVER_SETTINGS_HEADER}\n")
         fp.write(f"Solver: {solver_options.solver.name}\n")
         threads_used = (
             solver_options.num_threads
@@ -95,7 +95,7 @@ def add_resource_usage_summary(solver_options: datatypes.SolverOptions) -> None:
         fp.write(f"Threads: {threads_used}\n")
         fp.write(f"Time Limit: {solver_options.time_limit_s} s\n")
         fp.write(text_utils.AMPLICON_SEPARATOR + "\n")
-        fp.write("Resource Usage Summary:\n")
+        fp.write(f"{text_utils.RESOURCE_USAGE_HEADER}\n")
         for fn_call, profile in sorted(global_state.PROFILED_FN_CALLS.items()):
             fn_tag = (
                 f"{fn_call.fn_name}/{fn_call.call_ctr}"
@@ -133,5 +133,7 @@ def output_summary_amplicon_stats(
         fp.write(get_summary_header(was_amplicon_solved))
         for bp_graph in bp_graphs:
             output_amplicon_info(
-                bp_graph, fp, was_amplicon_solved[bp_graph.amplicon_idx]
+                bp_graph,
+                fp,
+                was_amplicon_solved.get(bp_graph.amplicon_idx, False),
             )

--- a/coral/summary/parsing.py
+++ b/coral/summary/parsing.py
@@ -236,12 +236,21 @@ def parse_full_summary(path: pathlib.Path) -> FullProfileSummary:
     summary_chunks = path.read_text().split(text_utils.AMPLICON_SEPARATOR)
     full_profile_summary = parse_header(summary_chunks.pop(0))
 
+    # The solver settings and resource usage sections are appended only when
+    # profiling is enabled, and only once the run finishes. Summaries from
+    # unprofiled or interrupted runs hold amplicon sections alone, so consume
+    # each trailing section only if it is actually present.
     resource_summary = None
-    if full_profile_summary.profiling_enabled:
+    if summary_chunks and text_utils.RESOURCE_USAGE_HEADER in (
+        summary_chunks[-1]
+    ):
         resource_summary = summary_chunks.pop()
 
     # Update solver info in-place
-    parse_solver_summary(summary_chunks.pop(), full_profile_summary)
+    if summary_chunks and text_utils.SOLVER_SETTINGS_HEADER in (
+        summary_chunks[-1]
+    ):
+        parse_solver_summary(summary_chunks.pop(), full_profile_summary)
 
     amplicon_summaries = summary_chunks
     for i, amplicon_summary_str in enumerate(amplicon_summaries):

--- a/coral/text_utils.py
+++ b/coral/text_utils.py
@@ -18,6 +18,11 @@ PROFILE_ENABLED_PATTERN = re.compile(r"Profiling Enabled: (True|False)")
 
 
 # Solver patterns
+# The solver settings and resource usage sections are only written when
+# profiling is enabled; their headers let the parser tell them apart from
+# amplicon sections.
+SOLVER_SETTINGS_HEADER = "Solver Settings:"
+RESOURCE_USAGE_HEADER = "Resource Usage Summary:"
 SOLVER_PATTERN = re.compile(r"Solver: (\S+)")
 THREADS_PATTERN = re.compile(r"Threads: (\d+)")
 TIME_LIMIT_PATTERN = re.compile(r"Time Limit: (\d+) s")

--- a/tests/test_merge_connected_amplicons.py
+++ b/tests/test_merge_connected_amplicons.py
@@ -8,8 +8,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from coral.breakpoint.infer_breakpoint_graph import LongReadBamToBreakpointMetadata
-from coral.core_types import Strand
-from coral.datatypes import AmpliconInterval, BPAlignments, Breakpoint, Node
+from coral.datatypes import (
+    AmpliconInterval,
+    BPAlignments,
+    Breakpoint,
+    Node,
+    Strand,
+)
 
 
 def make_metadata(

--- a/tests/test_summary_output.py
+++ b/tests/test_summary_output.py
@@ -1,0 +1,138 @@
+"""Tests for the run summary file (``*_summary.txt``).
+
+The summary doubles as a marker that the reconstruct stage ran (AmpliconClassifier
+keys off its presence), so it must be written even when no amplicons were found.
+
+The optional ``Solver Settings`` and ``Resource Usage Summary`` sections are
+appended only under ``--profile``, and only once a run completes; the parser must
+therefore treat both as optional rather than assuming a fixed section layout.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Iterator
+
+import pytest
+
+from coral import datatypes, global_state, text_utils
+from coral.breakpoint.breakpoint_graph import BreakpointGraph
+from coral.summary import output as summary_output
+from coral.summary import parsing as summary_parsing
+
+
+@pytest.fixture
+def summary_prefix(tmp_path: pathlib.Path) -> Iterator[pathlib.Path]:
+    """Point global state at a temp prefix, restoring it afterwards."""
+    provider = global_state.STATE_PROVIDER
+    saved = (provider.output_prefix, provider.should_profile)
+    saved_profiles = dict(global_state.PROFILED_FN_CALLS)
+    provider.output_prefix = str(tmp_path / "sample")
+    provider.should_profile = False
+    yield tmp_path / "sample"
+    provider.output_prefix, provider.should_profile = saved
+    global_state.PROFILED_FN_CALLS.clear()
+    global_state.PROFILED_FN_CALLS.update(saved_profiles)
+
+
+def make_graphs(num_amplicons: int) -> list[BreakpointGraph]:
+    return [BreakpointGraph(amplicon_idx=i) for i in range(num_amplicons)]
+
+
+def write_summary(bp_graphs: list[BreakpointGraph]) -> pathlib.Path:
+    summary_output.output_summary_amplicon_stats(
+        {bp_graph.amplicon_idx: False for bp_graph in bp_graphs}, bp_graphs
+    )
+    return global_state.STATE_PROVIDER.summary_filepath
+
+
+def add_resource_usage(output_dir: pathlib.Path) -> None:
+    global_state.STATE_PROVIDER.should_profile = True
+    global_state.PROFILED_FN_CALLS[
+        datatypes.FnCall("reconstruct_graphs", None)
+    ] = datatypes.ProfileResult(peak_ram_gb=1.5, runtime_s=42.0)
+    summary_output.add_resource_usage_summary(
+        datatypes.SolverOptions(
+            num_threads=4,
+            time_limit_s=7200,
+            output_dir=output_dir,
+            output_prefix="sample",
+            model_prefix="pyomo",
+            solver=datatypes.Solver.GUROBI,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# The file must exist even with no amplicons (e.g. an empty seeds file).
+# ---------------------------------------------------------------------------
+
+
+def test_summary_written_with_no_amplicons(summary_prefix: pathlib.Path) -> None:
+    summary_path = write_summary([])
+
+    assert summary_path.exists()
+    assert "0/0 amplicons solved." in summary_path.read_text()
+
+
+def test_summary_header_counts_all_amplicons(
+    summary_prefix: pathlib.Path,
+) -> None:
+    """Unsolved amplicons still count towards the denominator."""
+    summary_path = write_summary(make_graphs(3))
+
+    assert "0/3 amplicons solved." in summary_path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Optional trailing sections: present only under --profile, and only once the
+# run finishes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_amplicons", [0, 1, 2])
+def test_parse_unprofiled_summary(
+    summary_prefix: pathlib.Path, num_amplicons: int
+) -> None:
+    summary_path = write_summary(make_graphs(num_amplicons))
+
+    parsed = summary_parsing.parse_full_summary(summary_path)
+
+    assert len(parsed.amplicon_summaries) == num_amplicons
+    assert parsed.solver_used is None
+    assert parsed.profiles_by_fn == {}
+
+
+@pytest.mark.parametrize("num_amplicons", [0, 1, 2])
+def test_parse_profiled_summary(
+    summary_prefix: pathlib.Path, tmp_path: pathlib.Path, num_amplicons: int
+) -> None:
+    summary_path = write_summary(make_graphs(num_amplicons))
+    add_resource_usage(tmp_path)
+
+    parsed = summary_parsing.parse_full_summary(summary_path)
+
+    assert len(parsed.amplicon_summaries) == num_amplicons
+    assert parsed.solver_used == datatypes.Solver.GUROBI
+    assert parsed.threads_used == 4
+    assert parsed.solver_time_limit == 7200
+    assert "reconstruct_graphs" in parsed.profiles_by_fn
+
+
+def test_parse_interrupted_profiled_summary(
+    summary_prefix: pathlib.Path,
+) -> None:
+    """Profiling on in the header, but the run died before the trailing sections.
+
+    The amplicon sections must survive rather than being consumed as resource
+    usage.
+    """
+    global_state.STATE_PROVIDER.should_profile = True
+    summary_path = write_summary(make_graphs(2))
+    assert text_utils.RESOURCE_USAGE_HEADER not in summary_path.read_text()
+
+    parsed = summary_parsing.parse_full_summary(summary_path)
+
+    assert parsed.profiling_enabled is True
+    assert len(parsed.amplicon_summaries) == 2
+    assert parsed.solver_used is None


### PR DESCRIPTION
## Always write the summary file when reconstruct runs

  Small change. `*_summary.txt` was only written from inside the per-amplicon
  loop, so a run that found no amplicons — most often an empty seeds file —
  produced no summary at all. AmpliconClassifier uses that file as a marker
  that the reconstruct stage ran, so its absence can't be told apart from
  CoRAL never having run.

  ### Changes

  - **`cli.py`** — write the summary right after graph reconstruction, before
    cycle decomposition. Covers empty seed sets, `--skip-cycle-decomp`, and
    decomposition being interrupted. Decomposition overwrites it with real
    results as it goes.
  - **`cycle_decomposition.py`** — seed `was_amplicon_solved` with all graphs
    up front, so the header count is right throughout the run (a 5-amplicon
    sample used to read `1/1 amplicons solved` mid-run rather than the correct `1/5`).
  - **`summary/parsing.py`** — `parse_full_summary` unconditionally popped the
    `Solver Settings` section, which is only written under `--profile`. On an
    unprofiled summary it swallowed the last amplicon block and raised
    `ValueError`, or `IndexError` with no amplicons. Both trailing sections are
    now consumed only when present. This path is only reached by `coral score`
    / `plot_resources`, which are run profiled, which is why it went unnoticed.
  - **`tests/`** — `test_merge_connected_amplicons.py` imported `Strand` from
    `coral.core_types`, where it isn't defined (it's in `coral.datatypes`). The
    resulting collection error was aborting the whole suite. New
    `test_summary_output.py` covers the empty-amplicon summary and the parser's
    optional sections.

  ### Testing

  Tested locally. Full suite passes (26 tests, up from 12 collectable before
  the import fix). The new parser tests were confirmed to bite: reverting the
  guard fails 7 of 9 with exactly the `IndexError` / `ValueError` above.
  Verified summary writing and parsing across profiled × unprofiled and
  0/1/2 amplicons, plus a profiled run interrupted before the trailing
  sections are appended. No end-to-end run on a real BAM.